### PR TITLE
Handle listener closed error gracefully

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -209,6 +209,11 @@ func (p *Proxy) Serve(l net.Listener) error {
 				continue
 			}
 
+			if errors.Is(err, net.ErrClosed) {
+				log.Debugf("martian: listener closed, returning")
+				return err
+			}
+
 			log.Errorf("martian: failed to accept: %v", err)
 			return err
 		}


### PR DESCRIPTION
Do not print errors for listener closing